### PR TITLE
FIX Change build approach to "double-compile"

### DIFF
--- a/fake_src/piqi_rpc.app.src
+++ b/fake_src/piqi_rpc.app.src
@@ -1,6 +1,10 @@
 {application, piqi_rpc,
  [{description, "Fake .app file to make rebar happy"},
   {vsn, git},
+  % this mod name is here so that for whatever freaky reason this file gets used,
+  % at least `application:start(piqi_rpc)` will fail with an easy-to-debug
+  % reason.
+  {mod, [fake_module_piqi_rpc_should_not_be_called]},
   {modules, []},
   {applications, [kernel, stdlib]},
   {env, []}]}.

--- a/make/recompile-app-src-file
+++ b/make/recompile-app-src-file
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+test -f .app_src_recompiled || \
+    (touch .app_src_recompiled && rebar compile skip_deps=true)

--- a/rebar.config
+++ b/rebar.config
@@ -9,14 +9,15 @@
 
 
 {pre_hooks, [
-        {'compile', "make/post-hooks-get-deps"},
-        {'compile', "make/copy-app-file"}
+        {'compile', "make/post-hooks-get-deps"}
     ]}.
 
 {post_hooks, [
+        {'compile', "make/recompile-app-src-file"},
         {'delete-deps', "rm -f src include"},
         {'delete-deps', "ln -s fake_src src"},
         {'clean', "rm -f src include"},
-        {'clean', "ln -s fake_src src"}
+        {'clean', "ln -s fake_src src"},
+        {'clean', "rm -f .app_src_recompiled"}
     ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,10 @@
 
 {deps,
     [
-        {piqi, "", {git, "git@github.com:spilgames/piqi-erlang.git", {tag, "20121214"}}},
-        {webmachine, "1.9.1-3", {git, "git@github.com:spilgames/webmachine.git", {tag, "1.9.1-3"}}}
+        {piqi, "",{git, "git@github.com:spilgames/piqi-erlang.git",
+            {tag, "2012-01-29-dynamic-appsrc"}}},
+        {webmachine, "1.9.1-3", {git, "git@github.com:spilgames/webmachine.git",
+            {tag, "1.9.1-3"}}}
     ]}.
 
 


### PR DESCRIPTION
Previous approaches and why they don't work/are not nice:
- symlink to piqi_src on post-get-deps hook:
  
  post_hook for get-deps gets executed after THIS project is retrieved, not
  after its dependencies are (see [rebar issue](https://github.com/rebar/rebar/issues/61)), therefore the symlinking
  fails.
- symlink to piqi_src on pre-compile hook:
  
  the first thing rebar does is scan and consult `.app.src` files, so this will
  cause the "fake" `.app.src` file to be used, because it will ignore the new
  `.app.src` file in the (later) symlinked folder
- copy over .app file after compile
  - the file is static, so you will need to manually maintain modules, rebar
    does a better job at this using .app.src files
  - you also need to manually replace `{git, vsn}`

New approach: symlink on pre-compile, recompile twice on the very first compile
to ensure the right `.app.src` file was used.
