### PR TITLE
Fix application:env and stoping/starting related issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 REBAR ?= rebar
 
+.PHONY: all test deps dialyzer clean distclean
 
 all:
 	$(REBAR) compile
@@ -31,7 +32,3 @@ clean:
 
 distclean: clean
 	rm -rf ebin deps .dialyzer_deps_plt
-
-
-.PHONY: deps
-

--- a/src/piqi_rpc.erl
+++ b/src/piqi_rpc.erl
@@ -34,14 +34,7 @@ start() ->
 
 % @doc stop Piqi-RPC
 stop() ->
-    Res = application:stop(piqi_rpc),
-    % NOTE: can't call this cleanup from piqi_rpc_app:stop() or :prep_stop(),
-    % because of a dead-lock caused by the fact that piqi_rpc_http stores its
-    % routes configuration in application environmnent, and deletion of an entry
-    % from there needs to go through the application controller which is already
-    % busy stopping the application
-    catch piqi_rpc_http:cleanup(),
-    Res.
+    application:stop(piqi_rpc).
 
 
 % @doc stop Piqi-RPC and all dependencies that may have been started by start/0

--- a/src/piqi_rpc.erl
+++ b/src/piqi_rpc.erl
@@ -182,16 +182,16 @@ ensure_loaded(Mod) ->
 %% ======================================================================
 
 start_link(EnvTableId) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, EnvTableId, []).
+    Res = gen_server:start_link({local, ?MODULE}, ?MODULE, EnvTableId, []),
+    %% Make sure piqi_rpc_http is in sync with what we believe the current
+    %% services are
+    case Res of
+        {ok, _} -> piqi_rpc_http:configure();
+        _ -> ok
+    end,
+    Res.
 
 init(EnvTableId) ->
-    %% It might be a good idea to refresh the cowboy routes here just to be
-    %% sure, however doing something like:
-    %%
-    %%      spawn(fun piqi_rpc_http:configure/0),
-    %%
-    %% seems to cause rare race-conditions with ranch, so leaving it as is for
-    %% now.
     {ok, EnvTableId}.
 
 handle_call({get_env, Key}, _From, EnvTableId) ->

--- a/src/piqi_rpc.erl
+++ b/src/piqi_rpc.erl
@@ -16,13 +16,36 @@
 %% @doc Piqi-RPC high-level interface
 %%
 -module(piqi_rpc).
-
--export([start/0, stop/0, stop_all/0]).
--export([add_service/1, remove_service/1, get_services/0]).
-
+-behaviour(gen_server).
 
 -include("piqi_rpc.hrl").
 
+%% API
+-export([start/0, stop/0, stop_all/0]).
+
+%% RPC service management
+-export([
+    add_service/1,
+    remove_service/1,
+    remove_all_services/0,
+    get_services/0
+]).
+
+%% gen_server callbacks
+-export([start_link/1]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%% ======================================================================
+%% Starting / stopping piqi-rpc
+%% ======================================================================
 
 % @doc start Piqi-RPC
 start() ->
@@ -53,6 +76,10 @@ ensure_started(App) ->
         {error, {already_started, App}} -> ok
     end.
 
+%% ======================================================================
+%% Service management API
+%% ======================================================================
+
 -spec normalize_service_def/1 :: ( piqi_rpc_service_def() ) -> piqi_rpc_service().
 normalize_service_def(RpcService = {_ImplMod, _RpcMod, _UrlPath, _Options}) ->
     RpcService;
@@ -81,18 +108,27 @@ remove_service(RpcServiceDef) ->
     ok = remove_service_def(RpcService),
     ok = piqi_rpc_http:configure().
 
+-spec remove_all_services() -> ok.
+remove_all_services() ->
+    ok = piqi_rpc_http:cleanup(),
+    remove_all_service_defs().
+
 -spec get_services/0 :: () -> [piqi_rpc_service()].
 get_services() ->
     [Def || {_Url, Def} <- get_service_defs()].
 
 -spec get_service_defs/0 :: () -> [piqi_rpc_service_def()].
 get_service_defs() ->
-    get_env('rpc_services').
+    {ok, Defs} = get_env('rpc_services'),
+    Defs.
 
 -spec add_service_def/1 :: (piqi_rpc_service_def()) -> ok.
 add_service_def(RpcService = {_, _, UrlPath, _}) ->
     Services = get_service_defs(),
-    false = proplists:is_defined(UrlPath, Services),
+    case proplists:is_defined(UrlPath, Services) of
+        true -> erlang:error({url_path_already_used, UrlPath});
+        _ -> ok
+    end,
     set_env('rpc_services', [{UrlPath, RpcService} | Services]).
 
 -spec remove_service_def/1 :: (piqi_rpc_service_def()) -> ok.
@@ -100,16 +136,21 @@ remove_service_def({_, _, UrlPath, _}) ->
     Services = get_service_defs(),
     set_env('rpc_services', proplists:delete(UrlPath, Services)).
 
+-spec remove_all_service_defs() -> ok.
+remove_all_service_defs() ->
+    set_env('rpc_services', []).
+
+%% ======================================================================
+%% Internal helpers
+%% ======================================================================
+
 % @hidden
 get_env(Key) ->
-    case application:get_env(piqi_rpc, Key) of
-        {ok, X} -> X;
-        'undefined' -> []
-    end.
+    gen_server:call(?MODULE, {get_env, Key}).
 
 % @hidden
 set_env(Key, Value) ->
-    ok = application:set_env(piqi_rpc, Key, Value).
+    gen_server:call(?MODULE, {set_env, {Key, Value}}).
 
 check_modules({ImplMod, RpcMod, _, _}) ->
     ok = ensure_loaded(ImplMod),
@@ -134,3 +175,48 @@ ensure_loaded(Mod) ->
         {module, Mod} -> ok;
         E -> E
     end.
+
+
+%% ======================================================================
+%% gen_server callbacks
+%% ======================================================================
+
+start_link(EnvTableId) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, EnvTableId, []).
+
+init(EnvTableId) ->
+    %% It might be a good idea to refresh the cowboy routes here just to be
+    %% sure, however doing something like:
+    %%
+    %%      spawn(fun piqi_rpc_http:configure/0),
+    %%
+    %% seems to cause rare race-conditions with ranch, so leaving it as is for
+    %% now.
+    {ok, EnvTableId}.
+
+handle_call({get_env, Key}, _From, EnvTableId) ->
+    Result = case ets:lookup(EnvTableId, Key) of
+        [{Key, Res}] -> Res;
+        Other -> Other
+    end,
+    {reply, {ok, Result}, EnvTableId};
+
+handle_call({set_env, Obj={_Key, _Val}}, _From, EnvTableId) ->
+    true = ets:insert(EnvTableId, Obj),
+    {reply, ok, EnvTableId};
+
+handle_call(_Request, _From, State) ->
+    {reply, ignored, State}.
+
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/piqi_rpc_app.erl
+++ b/src/piqi_rpc_app.erl
@@ -30,7 +30,7 @@ start(_Type, _StartArgs) ->
     piqi_rpc_sup:start_link().
 
 prep_stop(_State) ->
-    ok = piqi_rpc_http:cleanup().
+    ok = piqi_rpc:remove_all_services().
 
 stop(_State) ->
     ok.

--- a/src/piqi_rpc_app.erl
+++ b/src/piqi_rpc_app.erl
@@ -19,16 +19,18 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
-
+-export([start/2, prep_stop/1, stop/1]).
 
 %
 % Applicaton callbacks
 %
 
 start(_Type, _StartArgs) ->
+    {ok, _} = piqi_rpc_http:start_listeners(),
     piqi_rpc_sup:start_link().
 
+prep_stop(_State) ->
+    ok = piqi_rpc_http:cleanup().
 
 stop(_State) ->
     ok.

--- a/src/piqi_rpc_app.erl
+++ b/src/piqi_rpc_app.erl
@@ -26,11 +26,13 @@
 %
 
 start(_Type, _StartArgs) ->
-    {ok, _} = piqi_rpc_http:start_listeners(),
-    piqi_rpc_sup:start_link().
+    {ok, _} = piqi_rpc_http:start_listener(),
+    {ok, Pid} = piqi_rpc_sup:start_link(),
+    {ok, Pid}.
 
 prep_stop(_State) ->
-    ok = piqi_rpc:remove_all_services().
+    ok = piqi_rpc:remove_all_services(),
+    ok = piqi_rpc_http:stop_listener().
 
 stop(_State) ->
     ok.

--- a/src/piqi_rpc_http.erl
+++ b/src/piqi_rpc_http.erl
@@ -31,12 +31,11 @@
 -include("piqi_rpc.hrl").
 
 start_listeners() ->
-    Routes = get_cowboy_routes(),
     cowboy:start_http(
         get_http_env(name),
         get_http_env(nb_acceptors),
         [{port, get_http_env(port)}],
-        [{env, [{dispatch, Routes}]}]
+        [{env, [{dispatch, []}]}]
     ).
 
 configure() ->

--- a/src/piqi_rpc_http.erl
+++ b/src/piqi_rpc_http.erl
@@ -15,24 +15,27 @@
 %%
 %% @doc Piqi-RPC HTTP interface
 %%
-%% Currently it is implemented on top of Webmachine
+%% Currently it is implemented on top of Cowboy.
 %%
 
 -module(piqi_rpc_http).
 
--export([start_link/0, cleanup/0]).
+-export([start_listeners/0, cleanup/0]).
+
 -export([add_service/1, remove_service/1, configure/0]).
-%-compile(export_all).
 
 -define(DEFAULT_PORT, 8080).
 -define(DEFAULT_NAME, piqi_rpc_server).
+-define(DEFAULT_NB_ACCEPTORS, 100).
 
 -include("piqi_rpc.hrl").
 
-start_link() ->
+start_listeners() ->
     Routes = get_cowboy_routes(),
-    cowboy:start_http(get_http_env(name, ?DEFAULT_NAME), get_http_env(nb_acceptors, 100),
-        [{port, get_http_env(port, ?DEFAULT_PORT)}],
+    cowboy:start_http(
+        get_http_env(name),
+        get_http_env(nb_acceptors),
+        [{port, get_http_env(port)}],
         [{env, [{dispatch, Routes}]}]
     ).
 
@@ -63,9 +66,8 @@ rpc_service_to_cowboy_route(_RpcService = {ImplMod, RpcMod, UrlPath, Options}) -
         {AdjustedPath, piqi_rpc_resource, {ImplMod, RpcMod, make_service_options(Options)}}
     ].
 
-% backward compatibility
 cleanup() ->
-    cowboy:set_env(get_http_env(name, ?DEFAULT_NAME), dispatch, []).
+    cowboy:stop_listener(get_http_env(name)).
 
 -spec add_service/1 :: ( piqi_rpc_service() ) -> ok.
 add_service(_RpcService = {_ImplMod, _RpcMod, _UrlPath, _Options}) ->
@@ -75,7 +77,20 @@ add_service(_RpcService = {_ImplMod, _RpcMod, _UrlPath, _Options}) ->
 remove_service(_RpcService = {_ImplMod, _RpcMod, _UrlPath, _Options}) ->
     configure().
 
+default_http_envs() ->
+    [
+        {port, ?DEFAULT_PORT},
+        {name, ?DEFAULT_NAME},
+        {nb_acceptors, ?DEFAULT_NB_ACCEPTORS}
+    ].
+
 % Utility
+get_http_env(Key) ->
+    get_http_env(
+      Key,
+      proplists:get_value(Key, default_http_envs())
+    ).
+
 get_http_env(Key, Default) ->
     case proplists:get_value(Key, get_env(piqi_rpc, http_server, [])) of
         undefined -> Default;

--- a/src/piqi_rpc_sup.erl
+++ b/src/piqi_rpc_sup.erl
@@ -36,12 +36,5 @@ start_link() ->
 %
 
 init(_Args) ->
-    PiqiRpcWebServer =
-        {piqi_rpc_http, % Piqi-RPC http server
-            {piqi_rpc_http, start_link, []},
-            permanent, 5000, worker,
-            dynamic % XXX
-        },
-
-    {ok, {{one_for_one, 1, 60}, [PiqiRpcWebServer]}}.
+    {ok, {{one_for_one, 1, 60}, []}}.
 

--- a/src/piqi_rpc_sup.erl
+++ b/src/piqi_rpc_sup.erl
@@ -25,6 +25,7 @@
 
 
 -define(SUPERVISOR, ?MODULE).
+-define(PIQI_RPC_ENV_TABLE, piqi_rpc_env_table).
 
 
 start_link() ->
@@ -33,8 +34,18 @@ start_link() ->
 
 %
 % Supervisor callback
-%
+
+
 
 init(_Args) ->
-    {ok, {{one_for_one, 1, 60}, []}}.
+    %% Table used to maintain registered services, specifically not named,
+    %% to avoid handling name clashes on restarts.
+    TableId = ets:new(
+        ?PIQI_RPC_ENV_TABLE, [set, public]
+    ),
+    ChildSpecs = [
+      {piqi_rpc, {piqi_rpc, start_link, [TableId]},
+        permanent, 5000, worker, [piqi_rpc]}
+    ],
+    {ok, {{one_for_one, 10, 10}, ChildSpecs}}.
 

--- a/test/piqi_rpc_eunit.erl
+++ b/test/piqi_rpc_eunit.erl
@@ -7,7 +7,15 @@
 
 piqi_rpc_test_() ->
     {foreach,
-        fun piqi_rpc:stop_all/0,
+        fun () ->
+            %% for cleaner / readable test logs, though I would recommend
+            %% re-enabling this during actual testing.
+            error_logger:tty(false)
+        end,
+        fun (_) ->
+            piqi_rpc:stop_all(),
+            ranch_bug_sleep()
+        end,
         [
          fun start_stop/0,
          fun stop_twice/0,
@@ -30,6 +38,7 @@ stop_twice() ->
 start_stop_start() ->
     ?assertEqual(ok, piqi_rpc:start()),
     ?assertEqual(ok, application:stop(piqi_rpc)),
+    ranch_bug_sleep(),
     ?assertEqual(ok, application:start(piqi_rpc)),
     ?assertEqual(ok, application:stop(piqi_rpc)).
 
@@ -40,6 +49,7 @@ clean_services_on_stop() ->
     ?assertEqual(ok, piqi_rpc:add_service(ServiceSpec)),
     ?assertEqual([erlang:append_element(ServiceSpec, [])], piqi_rpc:get_services()),
     ok = application:stop(piqi_rpc),
+    ranch_bug_sleep(),
     ok = application:start(piqi_rpc),
     ?assertEqual([], piqi_rpc:get_services()).
 
@@ -75,3 +85,11 @@ get_functions() ->
 rpc_method_1(_) -> ok.
 
 rpc_method_2(_) -> ok.
+
+ranch_bug_sleep() ->
+    %% there's a bug
+    %%  (https://github.com/extend/ranch/issues/74)
+    %% in `ranch` causing it to (in rare cases) fail in the presence of many
+    %% very quick starts / stops, so this is a temporary workaround, which is
+    %% needed inbetween start / stops.
+    timer:sleep(10).

--- a/test/piqi_rpc_eunit.erl
+++ b/test/piqi_rpc_eunit.erl
@@ -2,14 +2,19 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-compile(export_all).
 
-start_stop_test_() ->
+
+piqi_rpc_test_() ->
     {foreach,
         fun piqi_rpc:stop_all/0,
         [
          fun start_stop/0,
          fun stop_twice/0,
-         fun start_stop_start/0
+         fun start_stop_start/0,
+         fun clean_services_on_stop/0,
+         fun clean_services/0,
+         fun crash_gen_server/0
         ]
     }.
 
@@ -27,3 +32,46 @@ start_stop_start() ->
     ?assertEqual(ok, application:stop(piqi_rpc)),
     ?assertEqual(ok, application:start(piqi_rpc)),
     ?assertEqual(ok, application:stop(piqi_rpc)).
+
+clean_services_on_stop() ->
+    ?assertEqual(ok, piqi_rpc:start()),
+    ?assertEqual([], piqi_rpc:get_services()),
+    ServiceSpec = {?MODULE, ?MODULE, "eunit"},
+    ?assertEqual(ok, piqi_rpc:add_service(ServiceSpec)),
+    ?assertEqual([erlang:append_element(ServiceSpec, [])], piqi_rpc:get_services()),
+    ok = application:stop(piqi_rpc),
+    ok = application:start(piqi_rpc),
+    ?assertEqual([], piqi_rpc:get_services()).
+
+clean_services() ->
+    ok = piqi_rpc:start(),
+    [] = piqi_rpc:get_services(),
+    ServiceSpec = {?MODULE, ?MODULE, "eunit"},
+    ?assertEqual(ok, piqi_rpc:add_service(ServiceSpec)),
+    ?assertEqual([erlang:append_element(ServiceSpec, [])], piqi_rpc:get_services()),
+    ?assertEqual(ok, piqi_rpc:remove_all_services()),
+    ?assertEqual([], piqi_rpc:get_services()),
+    ok = application:stop(piqi_rpc).
+
+%% crash the piqi_rpc gen server and make sure it re-inits with the same
+%% services.
+crash_gen_server() ->
+    ok = piqi_rpc:start(),
+    ServiceSpec = {?MODULE, ?MODULE, "eunit"},
+    ok = piqi_rpc:add_service(ServiceSpec),
+    Pid = whereis(piqi_rpc),
+    exit(Pid, kill),
+    timer:sleep(100),
+    ?assertEqual([erlang:append_element(ServiceSpec, [])], piqi_rpc:get_services()).
+
+
+%% Helpers
+%%
+%% Pretend this module is a Piqi-RPC impl module.
+
+get_functions() ->
+    [ rpc_method_1, rpc_method_2 ].
+
+rpc_method_1(_) -> ok.
+
+rpc_method_2(_) -> ok.

--- a/test/piqi_rpc_eunit.erl
+++ b/test/piqi_rpc_eunit.erl
@@ -1,0 +1,29 @@
+-module(piqi_rpc_eunit).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+start_stop_test_() ->
+    {foreach,
+        fun piqi_rpc:stop_all/0,
+        [
+         fun start_stop/0,
+         fun stop_twice/0,
+         fun start_stop_start/0
+        ]
+    }.
+
+start_stop() ->
+    ?assertEqual(ok, piqi_rpc:start()),
+    ?assertEqual(ok, application:stop(piqi_rpc)).
+
+stop_twice() ->
+    ?assertEqual(ok, piqi_rpc:start()),
+    ?assertEqual(ok, application:stop(piqi_rpc)),
+    ?assertMatch({error, {not_started, _}}, application:stop(piqi_rpc)).
+
+start_stop_start() ->
+    ?assertEqual(ok, piqi_rpc:start()),
+    ?assertEqual(ok, application:stop(piqi_rpc)),
+    ?assertEqual(ok, application:start(piqi_rpc)),
+    ?assertEqual(ok, application:stop(piqi_rpc)).


### PR DESCRIPTION
This seems to work nicely.

However, I am a bit unhappy about the fact that there's a cyclic dependency between `piqi_rpc` and `piqi_rpc_http` modules. The fact that piqi-rpc listeners live in a different supervision tree opens up some more possibilities for race conditions, when adding/removing services and/or crashing, so it would be good to rethink this from scratch, but I'm too braindead for the moment to do it, so just pushing this out with a hope that someone else will spot any obvious issues if they're out there.
