### PR TITLE
capture stack trace before processing error

### DIFF
--- a/src/piqi_rpc_runtime.erl
+++ b/src/piqi_rpc_runtime.erl
@@ -84,13 +84,14 @@ encode_common(RpcMod, Encoder, TypeName, OutputFormat, Output, Options) ->
         try Encoder(Output)
         catch
             Class:Reason ->
+                Stacktrace = erlang:get_stacktrace(),
                 OutputStr = lists:flatten(format_term(Output)),
                 Error = io_lib:format(
                     "error encoding output:~n"
                     "~s,~n"
                     "exception: ~w:~P,~n"
                     "stacktrace: ~P",
-                    [OutputStr, Class, Reason, 30, erlang:get_stacktrace(), 30]),
+                    [OutputStr, Class, Reason, 30, Stacktrace, 30]),
                 throw_rpc_error(
                     {'invalid_output', iolist_to_binary(Error)})
         end,


### PR DESCRIPTION
This will make piqi errors output a relevant stacktrace instead of the error that occurs in the format_term call.
