### PR TITLE
Added Health endpoints

### DIFF
--- a/src/piqi_health_resource.erl
+++ b/src/piqi_health_resource.erl
@@ -1,0 +1,20 @@
+-module(piqi_health_resource).
+
+-export([init/3, handle/2, terminate/3]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+init({tcp, http}, Req, State) ->
+    {ok, Req, State}.
+
+handle(Req, State) ->
+    reply(200, [], <<"{\"status\": \"ok\"}">>, Req, State).
+
+terminate(_Reason, _Req, _State) ->
+    ok.
+
+reply(Code, Headers, Body, Req, State) ->
+    {ok, Req2} = cowboy_req:reply(Code, Headers, Body, Req),
+    {ok, Req2, State}.


### PR DESCRIPTION
If no health function is defined for a module (UrlPart),
  add a default one on /[UrlPaty/health/
  It will respond with HTTP 200, {"status": "ok"}
